### PR TITLE
Feat/add proper event for syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /vendor
 /.idea
 composer.lock

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can check all eloquent events here:  https://laravel.com/docs/5.5/eloquent#e
 New events are :
 
 ```
+pivotSyncing, pivotSynced,
 pivotAttaching, pivotAttached
 pivotDetaching, pivotDetached,
 pivotUpdating, pivotUpdated
@@ -56,6 +57,14 @@ public static function boot()
 {
     parent::boot();
 
+    static::pivotSyncing(function ($model, $relationName) {
+        //
+    });
+    
+    static::pivotSynced(function ($model, $relationName, $changes) {
+        //
+    });
+    
     static::pivotAttaching(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
     });
@@ -115,11 +124,9 @@ Dispatches **one** **pivotUpdating** and **one** **pivotUpdated** event.
 You can change only one row in the pivot table with updateExistingPivot.   
 
 **sync()**  
-Dispatches **more** **pivotAttaching** and **more** **pivotAttached** events, depending on how many rows are added in the pivot table. These events are not dispatched if nothing is attached.  
-Dispatches **one** **pivotDetaching** and **one** **pivotDetached** event, but you can see all deleted ids in the $pivotIds variable. This event is not dispatched if nothing is detached.  
-E.g. when you call sync() if two rows are added and two are deleted **two** **pivotAttaching** and **two** **pivotAttached** events and **one** **pivotDetaching** and **one** **pivotDetached** event will be dispatched.  
-If sync() is called but rows are not added or deleted events are not dispatched.  
-
+Dispatches **one** **pivotSyncing** and **one** **pivotSynced** event.  
+*How does it work:* The sync first detaches all associations and then attaches or updates new entries one by one.  
+Whether a row was attached/detached/updated during sync only **one** event is dispatched for all rows but in that case, you can see all the attached/detached/updated rows in the $changes variables.
 
 ## Usage
 
@@ -137,6 +144,13 @@ class User extends Model
     {
         return $this->belongsToMany(Role::class);
     }
+    
+    static::pivotSynced(function ($model, $relationName, $changes) {
+        echo 'pivotAttached';
+        echo get_class($model);
+        echo $relationName;
+        print_r($changes);
+    });
     
     static::pivotAttached(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         echo 'pivotAttached';

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "^5.5|^6.0|^7.0|^8.0"
+        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -8,6 +8,30 @@ use Illuminate\Database\Eloquent\Model;
 trait FiresPivotEventsTrait
 {
     /**
+     * Sync the intermediate tables with a list of IDs or collection of models.
+     *
+     * @param mixed $ids
+     * @param bool $detaching
+     *
+     * @return array
+     */
+    public function sync($ids, $detaching = true)
+    {
+        if (false === $this->parent->fireModelEvent('pivotSyncing', true, $this->getRelationName())) {
+            return false;
+        }
+
+        $parentResult = [];
+        $this->parent->withoutEvents(function () use ($ids, $detaching, &$parentResult) {
+            $parentResult = parent::sync($ids, $detaching);
+        });
+
+        $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName());
+
+        return $parentResult;
+    }
+
+    /**
      * Attach a model to the parent.
      *
      * @param mixed $id

--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -26,7 +26,7 @@ trait FiresPivotEventsTrait
             $parentResult = parent::sync($ids, $detaching);
         });
 
-        $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName());
+        $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName(), $parentResult);
 
         return $parentResult;
     }

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -17,12 +17,23 @@ trait PivotEventTrait
         return array_merge(
             parent::getObservableEvents(),
             [
+                'pivotSyncing', 'pivotSynced',
                 'pivotAttaching', 'pivotAttached',
                 'pivotDetaching', 'pivotDetached',
                 'pivotUpdating', 'pivotUpdated',
             ],
             $this->observables
         );
+    }
+
+    public static function pivotSyncing($callback, $priority = 0)
+    {
+        static::registerModelEvent('pivotSyncing', $callback, $priority);
+    }
+
+    public static function pivotSynced($callback, $priority = 0)
+    {
+        static::registerModelEvent('pivotSynced', $callback, $priority);
     }
 
     public static function pivotAttaching($callback, $priority = 0)


### PR DESCRIPTION
The `Sync` method uses behind the scenes first `detach` to detach all associations and then will use `attachNew` for each new entry, which leads to a lot of events being dispatched.